### PR TITLE
bake active mesh instead of duplicating avatar

### DIFF
--- a/FreezeFrame.csproj
+++ b/FreezeFrame.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -38,6 +38,10 @@
     <Reference Include="Assembly-CSharp">
       <HintPath>F:\Steam\steamapps\common\VRChat\MelonLoader\Managed\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
+    </Reference>
+    <Reference Include="VRCSDKBase">
+      <HintPath>F:\Steam\steamapps\common\VRChat\MelonLoader\Managed\VRCSDKBase.dll</HintPath>
+        <Private>false</Private>
     </Reference>
     <Reference Include="Il2Cppmscorlib">
       <HintPath>F:\Steam\steamapps\common\VRChat\MelonLoader\Managed\Il2Cppmscorlib.dll</HintPath>

--- a/VRCWSLibaryIntegration.cs
+++ b/VRCWSLibaryIntegration.cs
@@ -54,21 +54,13 @@ namespace FreezeFrame
             MelonLogger.Msg($"Freeze Frame was taken by {msg.Target} for user {msg.Content}");
             await AsyncUtils.YieldToMainThread();
             freezeMod.EnsureHolderCreated();
-            var rootObjects = SceneManager.GetActiveScene().GetRootGameObjects();
             if (msg.Content == "all")
             {
-                foreach (var item in rootObjects)
-                {
-                    freezeMod.InstantiateAvatar(item);
-                }
+                freezeMod.InstantiateAll();
             }
             else
             {
-                foreach (var item in rootObjects)
-                {
-                    if (item.GetComponent<VRCPlayer>()?.prop_String_2 == msg.Content)
-                        freezeMod.InstantiateAvatar(item);
-                }
+                freezeMod.InstantiateByName(msg.Content);
             }
         }
 


### PR DESCRIPTION
Active SkinnedMeshRenderer's will spawn MeshRenderer's.
No unused transform are duplicated and no additional cleanup is necessary.
Other active renderers are just copied in place.
Improves performance drastically. (28fps to 240fps with 150 Shino's in an empty world)